### PR TITLE
Adding ability to view/submit time per end in minutes as well as seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 PyGame app for timing curling games
 
 ## Overview
-The timer application uses a Flask RESTful API on the backend to setup the configuration of the timer settings and retrieve the current values of the timer. A PyGame front end display is provided. This project relies on the following third-party Python packages:
+The timer application uses a Flask RESTful API on the backend to set up the configuration of the timer settings and retrieve the current values of the timer. A PyGame front-end display is provided. This project relies on the following third-party Python packages:
 
 - Flask
 - Requests
@@ -16,7 +16,7 @@ The back end of the timer is written in `api.py`. To start the server:
 python api.py
 ```
 
-The server will start with Waitress if installed, or the Flask development server otherwise. A simple web utility is provided at the root of the server for controling the configuration of the timer. The host to bind to can be specified with the `--host` flag, and the port with the `--port` flag. The defaults are `0.0.0.0` and `5000`. The value of `0.0.0.0` for the host IP allows any device on the network to communicate with the server.
+The server will start with Waitress if installed, or the Flask development server otherwise. A simple web utility is provided at the root of the server for controlling the configuration of the timer. The host to bind to can be specified with the `--host` flag, and the port with the `--port` flag. The defaults are `0.0.0.0` and `5000`. The value of `0.0.0.0` for the host IP allows any device on the network to communicate with the server.
 
 The following API routes are supported:
 
@@ -37,14 +37,14 @@ The route `/game_times` returns everything needed by a front-end application to 
 |seconds| int | Number of seconds to display on the timer |
 |end_number| int | Ideal end number if keeping to the specified pace |
 |end_percentage| float | Percentage complete (out of 1) of the current end |
-|overtime| bool | True if the game is past the time alotted for that game and over time is allowed |
+|overtime| bool | True if the game is past the time allotted for that game and overtime is allowed |
 |time_per_end| int | Current setting of time per end in seconds |
 |total_time| int | Duration of the game in seconds |
 |uptime| int | How long the timer has been running in seconds |
 
 
 ## Front end
-An example PyGame front end is provided in `app.py` Simply run to start the front-end.
+An example PyGame front end is provided in `app.py` Simply run to start the front end.
 
 ```
 python app.py
@@ -52,7 +52,7 @@ python app.py
 
 The host IP of the backend server can be specified with the `--host` flag, and the port with the `--port` flag. The defaults are `127.0.0.1` and `5000`.
 
-If the server is not running, it will be started at run-time. The front-end has the following key bindings:
+If the server is not running, it will be started at run-time. The front end has the following key bindings:
 |Key|Action|
 |---|------|
 |r| Reset timer|

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -140,7 +140,7 @@ fieldset {
   padding: 2px 10px;
 }
 
-fieldset > input {
+input[type="radio"] {
   margin-right: 10px;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,12 +10,17 @@
 <body>
     <h1>Curling timer configuration</h1>
     <div class="card">
-        <form method="POST">
+        <form name="timerOptions" onsubmit="submitPreprocessing();" method="POST">
             <label for="num_ends">Number of ends:</label><br>
             <input type="text" id="num_ends" name="num_ends" value="{{num_ends}}" required><br>
             
-            <label for="time_per_end">Time per end (sec):</label><br>
+            <label for="time_per_end">Time per end:</label><br>
             <input type="text" id="time_per_end" name="time_per_end" value="{{time_per_end}}" required>
+            
+            <label for="time_per_end_seconds">Seconds</label>
+            <input type="radio" id="time_per_end_seconds" name="time_per_end_unit" value="sec" checked/>
+            <label for="time_per_end_minutes">Minutes</label>
+            <input type="radio" id="time_per_end_minutes" name="time_per_end_unit" value="min"/>
 
             <fieldset>
                 <legend>Allow overtime:</legend>                
@@ -50,5 +55,31 @@
         </div>
     </div>
 
+    <script>
+        var time_units = document.timerOptions.time_per_end_unit;
+        for (var i = 0; i < time_units.length; i++) {
+            time_units[i].addEventListener('change', function() {
+                var timePerEnd_Input = document.getElementById("time_per_end");
+                var timePerEnd = timePerEnd_Input.value;
+                if (this.value === "sec"){
+                    timePerEnd_Input.value = timePerEnd * 60;
+                } else {
+                    timePerEnd_Input.value = timePerEnd / 60;
+                }
+            });
+        }
+
+        function submitPreprocessing() {
+            var timePerEnd_Input = document.getElementById("time_per_end");
+            var timePerEnd = timePerEnd_Input.value;
+
+            var timePerEnd_Seconds = document.getElementById("time_per_end_seconds");
+
+            //convert back to seconds before form is submitted if currently showing minutes
+            if (!timePerEnd_Seconds.checked){
+                timePerEnd_Input.value = timePerEnd * 60;
+            }
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
1. Made a few spelling/grammar tweaks to the readme file
2. Added radio buttons to view "Time per end" in seconds or minutes in the UI for ease of use


When switching between seconds and minutes for "Time per end", the UI will simply update the value in the input textbox accordingly. When submitting the form for updates, we convert that value back to seconds always, because the value is ultimately stored and expected to be in seconds on the back end.