### PR TITLE
Timer UI updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ class IceClock:
     self._seconds = response.json().get("seconds")
     self._end_number = response.json().get("end_number")
     self._end_percentage = response.json().get("end_percentage")
-    self._overtime = response.json().get("overtime")
+    self._is_overtime = response.json().get("is_overtime")
     self._num_ends = response.json().get("num_ends")
     self._time_per_end = response.json().get("time_per_end")
     self._uptime = response.json().get("uptime")
@@ -139,21 +139,18 @@ class IceClock:
   def render_timer(self):
     color = self.get_text_color()
 
-    # Always display the timer during the game unless it is the last end or if over time is allowed
     text = self.timer_font.render("{:02d}:{:02d}:{:02d}".format(self._hours, self._minutes, self._seconds), True, color)
     text_rect = text.get_rect(center=(self.center["x"], self.center["y"] + 4*self.height // 16))
 
-    # Blink the timer on for one second and off for one second when over time
-    #if not self._overtime or self._seconds % 2:
     self.screen.blit(text, text_rect)
 
   def render_detail_text(self):
     color = self.get_text_color()
 
     is_last_end = self._end_number >= self._num_ends
-    if is_last_end and not self._overtime:
+    if is_last_end and not self._is_overtime:
       text = self.last_end_font.render("LAST END", True, color)
-    elif self._overtime:
+    elif self._is_overtime:
       text = self.last_end_font.render("OVERTIME", True, color)
     else:
       text = self.last_end_font.render("", True, color)
@@ -164,7 +161,7 @@ class IceClock:
   def render_end_number(self):
     color = self.get_text_color()
 
-    if not self._overtime:
+    if not self._is_overtime:
       end_num = self._end_number if self._end_number < self._num_ends else self._num_ends
       text = self.end_font.render("{:d}".format(end_num), True, color)
       text_rect = text.get_rect(center=(self.center["x"] - 2*self.width // 32, self.center["y"] - 3*self.height // 16))
@@ -178,7 +175,7 @@ class IceClock:
       text_rect = text.get_rect(center=(self.center["x"], self.center["y"] - 3*self.height // 16))
       
       # Blink the "OT" text on for one second and off for one second when over time
-      if not self._overtime or self._seconds % 2:
+      if not self._is_overtime or self._seconds % 2:
         self.screen.blit(text, text_rect)
 
   def render_end_progress_bar(self):
@@ -190,7 +187,7 @@ class IceClock:
     # Round to an integer multiple of the number of stones per end
     percentage = int(NUM_STONES_PER_END*self._end_percentage)/NUM_STONES_PER_END
     filled_height = int(self.bar_height * (1 - percentage))
-    if self._overtime:
+    if self._is_overtime:
       # Timer is expired and over time is allowed
       filled_height = int(self.bar_height)
     elif self._end_number > self._num_ends:
@@ -200,7 +197,7 @@ class IceClock:
     for rect in self.bar_rects:
       filled_rect = pygame.Rect(rect.x, rect.y + self.bar_height - filled_height,
                                 self.bar_width, filled_height)
-      color = Color.BAR_FG.value if not self._overtime else Color.OT.value
+      color = Color.BAR_FG.value if not self._is_overtime else Color.OT.value
       pygame.draw.rect(self.screen, color, filled_rect, border_radius = self.height//50)
 
       # Add dividers to progress bars for each stone
@@ -236,7 +233,7 @@ class IceClock:
     
     self.screen.fill(Color.SCREEN_BG.value)
     self.render_end_progress_bar()
-    self.render_end_progress_labels()
+    #self.render_end_progress_labels()
     self.render_timer()
     self.render_detail_text()
     self.render_end_number()

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,13 @@
 <body>
     <h1>Curling timer configuration</h1>
     <div class="card">
+        <form name="timerActions" method="POST">
+            <button type="submit" name="Start" style="background-color: green;">Start Timer</button>
+            <button type="submit" name="Stop" style="background-color: red;">Stop Timer</button>
+            <button type="submit" name="Reset" style="background-color: rgb(0, 2, 146);">Reset Timer</button>
+        </form>
+    </div>
+    <div class="card">
         <form name="timerOptions" onsubmit="submitPreprocessing();" method="POST">
             <label for="num_ends">Number of ends:</label><br>
             <input type="text" id="num_ends" name="num_ends" value="{{num_ends}}" required><br>
@@ -38,7 +45,7 @@
                 <input type="radio" id="countup" name="count_direction" value="1"  {% if count_direction == 1 %} checked {% endif %}/>
             </fieldset>
             
-            <button type="submit">Submit</button>
+            <button type="submit" name="Save">Save Options</button>
         </form>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,13 +11,17 @@
     <h1>Curling timer configuration</h1>
     <div class="card">
         <form name="timerActions" method="POST">
+            <h3>Timer Controls</h3>
+            <br />
             <button type="submit" name="Start" style="background-color: green;">Start Timer</button>
             <button type="submit" name="Stop" style="background-color: red;">Stop Timer</button>
-            <button type="submit" name="Reset" style="background-color: rgb(0, 2, 146);">Reset Timer</button>
+            <button type="submit" name="Reset" style="background-color: blue;">Reset Timer</button>
         </form>
     </div>
     <div class="card">
         <form name="timerOptions" onsubmit="submitPreprocessing();" method="POST">
+            <h3>Timer Options</h3>
+            <br />
             <label for="num_ends">Number of ends:</label><br>
             <input type="text" id="num_ends" name="num_ends" value="{{num_ends}}" required><br>
             
@@ -44,7 +48,7 @@
                 <label for="countup">Count up</label>
                 <input type="radio" id="countup" name="count_direction" value="1"  {% if count_direction == 1 %} checked {% endif %}/>
             </fieldset>
-            
+            <br />
             <button type="submit" name="Save">Save Options</button>
         </form>
     </div>


### PR DESCRIPTION
Added new "Timer Controls" section at top of HTML interface. This includes a start, stop, and reset button to directly control the timers, rather than timing automatically starting as soon as the application/API starts up. This will allow the extra level of control I think we'll need to make this clear and easy to use for the general club membership.

- Clicking the "Start Timer" button starts the timer and it will begin to count down/up depending on settings
- Clicking the "Stop Timer" button stops the timer and holds at the current remaining time
- Clicking the "Reset Timer" button resets back to the starting settings (e.g. 0 time if counting up, or total time if counting down)

![timer_controls](https://github.com/user-attachments/assets/24bc6a15-5773-4548-b579-b92dd99e3677)

In addition, I made some updates to the app UI. Instead of the timer text becoming the "LAST END" message, there is now an extra "Detail Text" box just below the time that is used to show "LAST END" and "OVERTIME" when necessary. This allows the timer to allows show and not be hidden.

I also made some changes based on a suggestion from Travis to add static text under the two vertical bars that says "STONES REMAINING" to make it clearer what those bars represent. The function that shows them is currently commented out, because I honestly don't think it's necessary, but for now I wanted to leave the functions in there in case we decide we do want something like that (you can see them in the screenshot below as an example, but running the app as-is, they're currently hidden/turned off).

![last_end](https://github.com/user-attachments/assets/0de1ccc9-f672-4f10-ad00-46bc3ffb53b2)

I also realized we had a number of functions all first determining what color to make the text for the various text boxes in the app, so I've moved those into one single get_text_color() function to reduce duplicate code.