### PR TITLE
Adding "timer adjustments" to allow adding and subtracting total game time

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,26 @@
                 </form>
             </div>
             <div class="card">
+                <form name="timerAdjustments" method="POST">
+                    <h3>Timer Adjustments</h3>
+                    <br />             
+                    
+                    <label for="add_minutes">More Time</label>
+                    <input type="radio" id="add_minutes" name="adjust_minutes_dir" value="add" checked="checked"/>
+                    <label for="subtract_minutes">Less Time</label>
+                    <input type="radio" id="subtract_minutes" name="adjust_minutes_dir" value="subtract" />
+                    
+                    <br />
+                    
+                    <label for="adjust_minutes">Minutes:</label>
+                    <input id="adjust_minutes" name="adjust_minutes" type="number" step="1" value="0" min="0" max="120" style="width: 75px;">
+
+                    <br />
+                    <button type="submit" name="AdjustTimer">Adjust Timer</button>
+                </form>
+                
+            </div>
+            <div class="card">
                 <h3>Style configuration</h3>
                 <p>Click <a href="{{url_for('style_preview')}}">here</a> for creating styles for the front end.</p>
                 <br/>        


### PR DESCRIPTION
Adding a new "Timer Adjustments" section to the main html page. This allows the user to adjust the start time of the game by adding or subtracting time, within limits.

![timer_adjustments](https://github.com/user-attachments/assets/67cbe206-3421-45bc-a20b-8cf16ab56890)

Currently using the "More Time" and "Less Time" verbiage rather than "Add" and "Subtract" to try and make it clearer what each does, especially if you were to switch the timer between counting down and counting up.

There are restrictions on the values you can input that should force it to be an integer between 0 and 120. This also works fine whether the timer is currently paused/stopped or actively running.