### PR TITLE
Enhance to support jobs that run a single time.

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -14,6 +14,7 @@ jobstores = {
   "default": SQLAlchemyJobStore(url="sqlite:///{}".format(DATABASE_PATH)),
   "league": SQLAlchemyJobStore(url="sqlite:///{}".format(DATABASE_PATH), tablename='league_jobs'),
   "bonspiel": SQLAlchemyJobStore(url="sqlite:///{}".format(DATABASE_PATH), tablename='bonspiel_jobs'),
+  "one_time_job": SQLAlchemyJobStore(url="sqlite:///{}".format(DATABASE_PATH), tablename='one_time_jobs'),
   }
 scheduler = BackgroundScheduler(jobstores=jobstores)
 scheduler.start(paused=True)
@@ -23,13 +24,14 @@ class Permissions(Enum):
   # If you wish to add new permissions, add them to the end
   # If you need to remove a permission, just mark it as deprecated but keep the value
   # If you want to change the order that pages are displayed in the admin panel, change the order in the UI code, not here
-  MANAGE_USERS             = 0b000000000001
-  MANAGE_LEAGUE_SCHEDULE   = 0b000000000010
-  MANAGE_BONSPIEL_SCHEDULE = 0b000000000100
-  MANAGE_PROFILES          = 0b000000001000
-  VIEW_SCHEDULE            = 0b000000010000
-  UPLOAD_STYLES            = 0b000000100000
-  CHANGE_STYLES            = 0b000001000000
+  MANAGE_USERS                 = 0b000000000001
+  MANAGE_LEAGUE_SCHEDULE       = 0b000000000010
+  MANAGE_BONSPIEL_SCHEDULE     = 0b000000000100
+  MANAGE_PROFILES              = 0b000000001000
+  VIEW_SCHEDULE                = 0b000000010000
+  UPLOAD_STYLES                = 0b000000100000
+  CHANGE_STYLES                = 0b000001000000
+  MANAGE_ONE_TIME_JOB_SCHEDULE = 0b000010000000
 
 def load_profiles(db_path):
   conn = sqlite3.connect(db_path)

--- a/admin/templates/admin/one_time_job_scheduler.html
+++ b/admin/templates/admin/one_time_job_scheduler.html
@@ -1,0 +1,77 @@
+{% extends "admin/base.html" %}
+{% block head %}
+  <title>One Time Job Scheduler - Curling timer</title>
+{% endblock %}
+{% block header %}
+  One Time Job Scheduler
+  <button class="popover-button" popovertarget="help-popover">
+      <img src="{{ url_for('static', filename='images/circle-info.svg') }}"
+          alt="Timer help" height="20" width="20" />
+  </button>
+{% endblock %}
+{% block content %}
+  <div class="card">
+      <h2>Current jobs</h2>
+          <table>
+              <thead>
+              <tr>
+                  <th>Job ID</th>
+                  <th>Start date</th>
+                  <th>Profile</th>
+                  <th>Actions</th>
+              </tr>
+              </thead>
+              <tbody>
+        {% for job in jobs %}
+              <tr>
+              <form method="post" style="display:inline;">
+                  <td>{{ job["id"] }}</td>
+                  <td>
+                    <p class="mobile-label">Start date</p>
+                    <input type="datetime-local" id="start_datetime" name="start_datetime" value="{{ job['start_dt'].strftime('%Y-%m-%dT%H:%M') }}" required><br>
+                  </td>
+                  <td>
+                    <p class="mobile-label">Profile</p>
+                      <select name="profile" required>
+                          {% for profile in profiles %}
+                            <option value="{{ profile }}" {% if profile == job["profile"] %}selected{% endif %}>{{ profile }}</option>
+                          {% endfor %}
+                      </select>
+                  <td>
+              <input name="action" type="hidden" value="edit">
+              <input name="job_id" type="hidden" value="{{ job['id'] }}">
+              <button type="submit">Edit</button>
+            </form>
+            <form method="post" style="display:inline;">
+              <input name="action" type="hidden" value="delete">
+              <input name="job_id" type="hidden" value="{{ job['id'] }}">
+              <button type="submit" style="background-color: red;">Delete</button>
+            </form>
+          </td>
+      </tr>
+        {% endfor %}
+      </tbody>
+  </table>
+  </div>
+  <div class="card">
+      <h2>Add job</h2>
+      <form name="add_job" method="post">
+        <input name="action" type="hidden" value="add">
+        <label for="job_id">Job Name:</label><br>
+        <input name="job_id" placeholder="Job name" required><br>
+        <label for="start_datetime">Start Date and time:</label><br>
+        <input type="datetime-local" id="start_datetime" name="start_datetime" required><br>
+        <label for="profile">Profile:</label><br>
+        <select name="profile" required>
+          {% for profile in profiles %}
+            <option value="{{ profile }}">{{ profile }}</option>
+          {% endfor %}
+        </select><br>
+        <button type="submit" value="Add Job">Add Job</button>
+      </form>
+  </div>
+
+  <div popover id="help-popover">
+    {% include 'partials/timer_help.html' %}
+  </div>
+{% endblock %}

--- a/admin/views.py
+++ b/admin/views.py
@@ -56,6 +56,7 @@ def index():
         Permissions.MANAGE_PROFILES,
         Permissions.MANAGE_LEAGUE_SCHEDULE,
         Permissions.MANAGE_BONSPIEL_SCHEDULE,
+        Permissions.MANAGE_ONE_TIME_JOB_SCHEDULE,
     ]
     for perm in Permissions:
       if perm not in display_order:
@@ -214,6 +215,100 @@ def manage_league_schedule():
   ]
   profiles = load_profiles(DATABASE_PATH)
   return render_template("admin/league_scheduler.html", jobs=jobs, profiles=profiles)
+
+def add_one_time_job():
+  job_id = request.form['job_id']
+  start_dt_str = request.form['start_datetime']
+  start_dt = datetime.fromisoformat(start_dt_str)
+  profile = request.form['profile']
+
+  if scheduler.get_job(job_id):
+    flash('Job ID already exists!')
+    return redirect(url_for('admin.manage_one_time_job_schedule'))
+
+  scheduler.add_job(
+    id=job_id,
+    name="one_time_job",
+    func="timer_scheduler:start_one_time_job",
+    args=[profile],
+    trigger="cron",
+    year=start_dt.year,
+    month=start_dt.month,
+    day=start_dt.day,
+    hour=start_dt.hour,
+    minute=start_dt.minute,
+    replace_existing=False,
+    jobstore='one_time_job'
+  )
+  flash('Job added successfully!')
+
+def edit_one_time_job():
+  job_id = request.form['job_id']
+  start_dt_str = request.form['start_datetime']
+  start_dt = datetime.fromisoformat(start_dt_str)
+  profile = request.form['profile']
+
+  job = scheduler.get_job(job_id)
+  if not job:
+    flash('Job not found!')
+    return redirect(url_for('admin.manage_one_time_job_schedule'))
+
+  trigger = CronTrigger(
+    year=start_dt.year,
+    month=start_dt.month,
+    day=start_dt.day,
+    hour=start_dt.hour,
+    minute=start_dt.minute,
+  )
+
+  scheduler.modify_job(
+    job_id,
+    trigger=trigger,
+    args=[profile]
+  )
+  flash('Job updated successfully!')
+
+def delete_one_time_job():
+  job_id = request.form['job_id']
+  job = scheduler.get_job(job_id)
+  if not job:
+    flash('Job not found!')
+    return redirect(url_for('admin.manage_one_time_job_schedule'))
+
+  scheduler.remove_job(job_id)
+  flash('Job deleted successfully!')
+
+@admin.route('/one_time_job_scheduler', methods=['GET', 'POST'])
+@protected_route
+def manage_one_time_job_schedule():
+  if not check_permissions(Permissions.MANAGE_ONE_TIME_JOB_SCHEDULE):
+    return redirect(url_for('admin.unauthorized'))
+
+  if request.method == 'POST':
+    action = request.form['action']
+
+    if action == 'add':
+      add_one_time_job()
+    elif action == 'delete':
+      delete_one_time_job()
+    elif action == 'edit':
+      edit_one_time_job()
+
+  jobs = scheduler.get_jobs(jobstore='one_time_job')
+  jobs.sort(key=lambda j: j.next_run_time.replace(tzinfo=None) if j.next_run_time else datetime.max)
+  jobs = [
+      {
+        "id": job.id,
+        "start_dt": datetime(year=int(str(job.trigger.fields[0])),
+                             month=int(str(job.trigger.fields[1])),
+                             day=int(str(job.trigger.fields[2])),
+                             hour=int(str(job.trigger.fields[5])),
+                             minute=int(str(job.trigger.fields[6]))),
+        "profile": job.args[0]
+      } for job in jobs
+  ]
+  profiles = load_profiles(DATABASE_PATH)
+  return render_template("admin/one_time_job_scheduler.html", jobs=jobs, profiles=profiles)
 
 def add_bonspiel_job():
   job_id = request.form['job_id']

--- a/timer_scheduler.py
+++ b/timer_scheduler.py
@@ -26,6 +26,14 @@ def start_timer(profile):
   requests.get('http://localhost:5000/reset')
   requests.get('http://localhost:5000/start')
 
+def start_one_time_job(profile):
+  is_timer_running = requests.get('http://localhost:5000/config?key=is_timer_running').json().get('is_timer_running', False)
+  if is_timer_running:
+    logger.info("Timer is already running. Skipping one-time job start.")
+    return
+
+  start_timer(profile)
+
 def start_bonspiel(job_id, time_to_chime, time_per_end, stones_per_end, timer_count_in, allow_ot, count_direction):
   # Load settings for bonspiel
   settings = [


### PR DESCRIPTION
The PR adds the ability to schedule jobs that run a single time. They are scheduled to follow a league profile and have an associated date and time to start. An associated webpage to manage these jobs is added. The timer scheduling system automatically clears out jobs once they have run. These jobs have a lower priority than any other job. This means that if a one time job is scheduled to start while the timer is currently running then it will simply skip starting the job.